### PR TITLE
Include paused campaigns + new checks

### DIFF
--- a/bq_queries/01-image_assets.sql
+++ b/bq_queries/01-image_assets.sql
@@ -26,7 +26,7 @@ WITH count_image_assets AS (
   GROUP BY 1, 2
 ),
 count_logos AS (
-  SELECT 
+  SELECT
     campaign_id,
     asset_group_id,
     COUNT(*) AS count_logos
@@ -84,11 +84,12 @@ count_landscape_logos AS (
   AND asset_sub_type = 'LOGO'
   GROUP BY 1, 2
 )
-SELECT DISTINCT
+SELECT
   AGS.account_id,
   AGS.account_name,
   AGS.campaign_id,
   AGS.campaign_name,
+  AGS.campaign_status,
   AGS.asset_group_id,
   AGS.asset_group_name,
   COALESCE(CIA.count_images,0) AS count_images,
@@ -120,4 +121,4 @@ LEFT JOIN count_square_logos AS CSL
 LEFT JOIN count_landscape_logos AS CRL
   ON CRL.campaign_id = AGS.campaign_id
   AND CRL.asset_group_id = AGS.asset_group_id
-GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
+GROUP BY ALL

--- a/bq_queries/03-primary_conversion_action_search.sql
+++ b/bq_queries/03-primary_conversion_action_search.sql
@@ -57,7 +57,7 @@ CONVERSION_ACTION_FREQUENCY AS (
     RANK() OVER (PARTITION BY account_id, campaign_type
       ORDER BY COUNT(DISTINCT campaign_id) DESC) AS row_num
   FROM CONVERSION_SPLIT_GROUPED_W_CUSTOM
-  WHERE campaign_type = "SEARCH"
+  WHERE campaign_type = 'SEARCH'
   GROUP BY
     account_id,
     conversion_name,
@@ -80,7 +80,7 @@ MOST_USED_CONVERSIONS AS (
   JOIN CONVERSION_ACTION_FREQUENCY_GROUPED CF
     USING (account_id)
   WHERE row_num = 1
-  AND CS.campaign_type = "SEARCH"
+  AND CS.campaign_type = 'SEARCH'
 )
 SELECT DISTINCT
   account_id,

--- a/bq_queries/04-text_assets.sql
+++ b/bq_queries/04-text_assets.sql
@@ -60,11 +60,12 @@ count_short_descriptions AS (
     AND LENGTH(AGA.text_asset_text) <= 60
   GROUP BY 1, 2
 )
-SELECT DISTINCT
+SELECT
   AGS.account_id,
   AGS.account_name,
   AGS.campaign_id,
   AGS.campaign_name,
+  AGS.campaign_status,
   AGS.asset_group_id,
   AGS.asset_group_name,
   COALESCE(CH.count_headlines,0) AS count_headlines,
@@ -88,4 +89,4 @@ LEFT JOIN count_short_descriptions AS CSD
 LEFT JOIN count_long_headlines AS CLH
   ON CLH.campaign_id = AGS.campaign_id
   AND CLH.asset_group_id = AGS.asset_group_id
-GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12

--- a/bq_queries/05-video_assets.sql
+++ b/bq_queries/05-video_assets.sql
@@ -35,6 +35,7 @@ AS (
     AGS.account_name,
     AGS.campaign_id,
     AGS.campaign_name,
+    AGS.campaign_status,
     AGS.asset_group_id,
     AGS.asset_group_name,
     AGS.ad_strength,

--- a/bq_queries/06-assetssnapshots.sql
+++ b/bq_queries/06-assetssnapshots.sql
@@ -12,21 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CREATE OR REPLACE TABLE `{bq_dataset}_bq.assetssnapshots_${format(yesterday(),'yyyyMMdd')}` AS (
-SELECT
-  CURRENT_DATE()-1 as day,
-  AGA.account_id,
-  AGA.account_name,
-  AGA.asset_group_id,
-  AGA.asset_group_name,
-  AGA.campaign_name,
-  AGA.campaign_id,
-  AGA.asset_id,
-  AGA.asset_sub_type,
-  AGA.asset_performance,
-  AGA.text_asset_text,
-  COALESCE(AGA.image_url,CONCAT('https://www.youtube.com/watch?v=',AGA.video_id)) AS image_video,
-  COALESCE(AGA.image_url,CONCAT('https://i.ytimg.com/vi/', CONCAT(AGA.video_id, '/hqdefault.jpg'))) AS image_video_url
-FROM {bq_dataset}.assetgroupasset AGA
-WHERE asset_performance NOT IN ('PENDING','UNKNOWN')
-GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13)
+  CREATE OR REPLACE TABLE `{bq_dataset}_bq.assetssnapshots_${format(yesterday(),'yyyyMMdd')}` AS (
+  SELECT
+    CURRENT_DATE()-1 as day,
+    AGA.account_id,
+    AGA.account_name,
+    AGA.asset_group_id,
+    AGA.asset_group_name,
+    AGA.campaign_name,
+    AGA.campaign_id,
+    AGA.campaign_status,
+    AGA.asset_id,
+    AGA.asset_sub_type,
+    AGA.asset_performance,
+    AGA.text_asset_text,
+    COALESCE(AGA.image_url,CONCAT('https://www.youtube.com/watch?v=', AGA.video_id)) AS image_video,
+    COALESCE(AGA.image_url,CONCAT('https://i.ytimg.com/vi/', CONCAT(AGA.video_id, '/hqdefault.jpg'))) AS image_video_url
+  FROM {bq_dataset}.assetgroupasset AGA
+  WHERE asset_performance NOT IN ('PENDING','UNKNOWN')
+  GROUP BY ALL
+)

--- a/bq_queries/07-campaign_data.sql
+++ b/bq_queries/07-campaign_data.sql
@@ -18,7 +18,7 @@ WITH
     SELECT
       account_id,
       campaign_id,
-      CASE 
+      CASE
         WHEN campaign_mcv_troas IS NOT NULL THEN campaign_mcv_troas
         WHEN campaign_troas IS NOT NULL THEN campaign_troas
         WHEN bidding_strategy_mcv_troas IS NOT NULL THEN bidding_strategy_mcv_troas
@@ -53,7 +53,7 @@ WITH
       COUNT(DISTINCT AGS.asset_group_id) AS number_of_audience_signals,
       AGS.campaign_id AS campaign_id
     FROM `{bq_dataset}.assetgroupsignal` AS AGS
-    GROUP BY 
+    GROUP BY
       campaign_id
   ),
   CAMPIAGN_SITELINKS_DATA AS (
@@ -131,6 +131,10 @@ SELECT
   C.conversions_value,
   PCA.conversion_name AS pmax_conversion,
   PCAS.conversion_name AS primary_conversion_search,
+  REGEXP_CONTAINS(ARRAY_TO_STRING(C.asset_automation_settings, ','), r'"asset_automation_type"\s*\:\s*"TEXT_ASSET_AUTOMATION"\s*,\s*"asset_automation_status"\s*\:\s*"OPTED_IN"') AS has_automatic_text_asset_automation,
+  COUNT(IF(NC.type = 'KEYWORD' AND NC.negative, 1, null)) > 0 AS has_keyword_exclusions,
+  COUNT(IF(NC.type = 'USER_LIST' AND NC.negative, 1, null)) > 0 AS has_users_exclusions,
+  CLG.customer_acquisition_goal_settings_optimization_mode AS customer_acquisition_optimization_mode,
   C.negative_geo_target_type as negative_geo_target_type,
   C.positive_geo_target_type as positive_geo_target_type,
   IF (ASCC.number_of_audience_signals IS NOT NULL, ASCC.number_of_audience_signals, 0) AS number_of_audience_signals,
@@ -138,20 +142,20 @@ SELECT
   IF (C.negative_geo_target_type != 'PRESENCE_OR_INTEREST', "X", "Yes") as negative_geo_target_type_configured_good,
   IF (C.positive_geo_target_type != 'PRESENCE_OR_INTEREST', "X", "Yes") as positive_geo_target_type_configured_good,
   CASE
-    WHEN (IF(SD.campaign_sitelinks IS NULL, 0, SD.campaign_sitelinks) 
+    WHEN (IF(SD.campaign_sitelinks IS NULL, 0, SD.campaign_sitelinks)
     + IF(ASD.account_sitelinks IS NULL, 0, ASD.account_sitelinks)) >= 4
       THEN 0
-    ELSE 4 - (IF(SD.campaign_sitelinks IS NULL, 0, SD.campaign_sitelinks) 
+    ELSE 4 - (IF(SD.campaign_sitelinks IS NULL, 0, SD.campaign_sitelinks)
     + IF(ASD.account_sitelinks IS NULL, 0, ASD.account_sitelinks))
   END AS missing_sitelinks,
   CASE
-     WHEN (IF(CD.campaign_callouts IS NULL, 0, CD.campaign_callouts) 
+     WHEN (IF(CD.campaign_callouts IS NULL, 0, CD.campaign_callouts)
      + IF(ACD.account_callouts IS NULL, 0, ACD.account_callouts)) >= 1
       THEN 0
     ELSE 1
   END AS missing_callouts,
   CASE
-     WHEN (IF(SSD.campaign_structsnippets IS NULL, 0, SSD.campaign_structsnippets) 
+     WHEN (IF(SSD.campaign_structsnippets IS NULL, 0, SSD.campaign_structsnippets)
      + IF(ASSD.account_structsnippets IS NULL, 0, ASSD.account_structsnippets)) >= 1
       THEN 0
     ELSE 1
@@ -185,7 +189,11 @@ FROM `{bq_dataset}.campaign_settings` C
   LEFT JOIN `{bq_dataset}_bq.primary_conversion_action_pmax` AS PCA
     ON PCA.account_id = C.account_id
     AND PCA.campaign_id = C.campaign_id
-  LEFT JOIN ASSET_GROUPS_COUNT AS AGC
+    LEFT JOIN `{bq_dataset}.campaign_lifecycle_goals` AS CLG
+    ON CLG.campaign = C.campaign_resource_name
+  LEFT JOIN `{bq_dataset}.negative_criteria` AS NC
+    ON NC.campaign_resource_name = C.campaign_resource_name
+LEFT JOIN ASSET_GROUPS_COUNT AS AGC
     ON C.campaign_id = AGC.campaign_id
   LEFT JOIN AUDIENCE_SIGNALS_COUNT AS ASCC
     ON C.campaign_id = ASCC.campaign_id
@@ -202,4 +210,5 @@ FROM `{bq_dataset}.campaign_settings` C
   LEFT JOIN ACCOUNT_STRUCTURED_SNIPPETS_DATA AS ASSD
     ON C.account_id = ASSD.account_id
   LEFT JOIN `{bq_dataset}.ocid_mapping` AS OCID
-    ON OCID.customer_id = C.account_id;
+    ON OCID.customer_id = C.account_id
+GROUP BY ALL;

--- a/bq_queries/08-assetsummary.sql
+++ b/bq_queries/08-assetsummary.sql
@@ -29,20 +29,17 @@ CREATE OR REPLACE TABLE `{bq_dataset}_bq.summaryassets` AS (
     COALESCE(AGA.image_url,CONCAT('https://www.youtube.com/watch?v=',AGA.video_id)) AS image_video,
     COALESCE(AGA.image_url,CONCAT('https://i.ytimg.com/vi/', CONCAT(AGA.video_id, '/hqdefault.jpg'))) AS image_video_url,
     OCID.ocid,
-    CS.last_30_day_campaign_cost
+    AGA.date,
+    SUM(AGA.impressions) AS impressions,
+    SUM(AGA.clicks) AS clicks,
+    SUM(AGA.conversions) AS conversions,
+    SUM(AGA.conversions_value) AS conversions_value,
+    SUM(AGA.cost_micros)/1e6 AS cost
   FROM `{bq_dataset}.assetgroupasset` AS AGA
   JOIN `{bq_dataset}.assetgroupsummary` AS AGS
     USING(asset_group_id)
   LEFT JOIN `{bq_dataset}.ocid_mapping` AS OCID
     ON OCID.customer_id = AGA.account_id
-  LEFT JOIN (
-    SELECT
-      campaign_id,
-      SUM(cost) AS last_30_day_campaign_cost
-    FROM `{bq_dataset}.campaign_settings`
-    WHERE PARSE_DATE('%Y-%m-%d', date) >= DATE_SUB(CURRENT_DATE(),  INTERVAL 30 DAY)
-    GROUP BY campaign_id
-      ) AS CS ON AGA.campaign_id = CS.campaign_id
   WHERE AGA.asset_performance NOT IN ('PENDING','UNKNOWN')
     AND AGA.campaign_id
       IN (SELECT campaign_id FROM `{bq_dataset}.campaign_settings`)

--- a/bq_queries/08-assetsummary.sql
+++ b/bq_queries/08-assetsummary.sql
@@ -13,36 +13,38 @@
 # limitations under the License.
 
 CREATE OR REPLACE TABLE `{bq_dataset}_bq.summaryassets` AS (
-SELECT
-  AGA.account_id,
-  AGA.account_name,
-  AGA.asset_group_id,
-  AGA.asset_group_name,
-  AGA.campaign_name,
-  AGA.campaign_id,
-  AGA.asset_id,
-  AGA.asset_sub_type,
-  AGA.asset_performance,
-  AGA.text_asset_text,
-  AGS.asset_group_status,
-  COALESCE(AGA.image_url,CONCAT('https://www.youtube.com/watch?v=',AGA.video_id)) AS image_video,
-  COALESCE(AGA.image_url,CONCAT('https://i.ytimg.com/vi/', CONCAT(AGA.video_id, '/hqdefault.jpg'))) AS image_video_url,
-  OCID.ocid,
-  CS.last_30_day_campaign_cost
-FROM `{bq_dataset}.assetgroupasset` AS AGA
-JOIN `{bq_dataset}.assetgroupsummary` AS AGS
-  USING(asset_group_id)
-LEFT JOIN `{bq_dataset}.ocid_mapping` AS OCID
-  ON OCID.customer_id = AGA.account_id
-LEFT JOIN (
   SELECT
-    campaign_id,
-    SUM(cost) AS last_30_day_campaign_cost
-  FROM `{bq_dataset}.campaign_settings`
-  WHERE PARSE_DATE('%Y-%m-%d', date) >= DATE_SUB(CURRENT_DATE(),  INTERVAL 30 DAY)
-  GROUP BY campaign_id
-    ) AS CS ON AGA.campaign_id = CS.campaign_id
-WHERE AGA.asset_performance NOT IN ('PENDING','UNKNOWN')
-  AND AGA.campaign_id
-    IN (SELECT campaign_id FROM `{bq_dataset}.campaign_settings`)
-GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15);
+    AGA.account_id,
+    AGA.account_name,
+    AGA.asset_group_id,
+    AGA.asset_group_name,
+    AGA.campaign_name,
+    AGA.campaign_id,
+    AGA.campaign_status,
+    AGA.asset_id,
+    AGA.asset_sub_type,
+    AGA.asset_performance,
+    AGA.text_asset_text,
+    AGS.asset_group_status,
+    COALESCE(AGA.image_url,CONCAT('https://www.youtube.com/watch?v=',AGA.video_id)) AS image_video,
+    COALESCE(AGA.image_url,CONCAT('https://i.ytimg.com/vi/', CONCAT(AGA.video_id, '/hqdefault.jpg'))) AS image_video_url,
+    OCID.ocid,
+    CS.last_30_day_campaign_cost
+  FROM `{bq_dataset}.assetgroupasset` AS AGA
+  JOIN `{bq_dataset}.assetgroupsummary` AS AGS
+    USING(asset_group_id)
+  LEFT JOIN `{bq_dataset}.ocid_mapping` AS OCID
+    ON OCID.customer_id = AGA.account_id
+  LEFT JOIN (
+    SELECT
+      campaign_id,
+      SUM(cost) AS last_30_day_campaign_cost
+    FROM `{bq_dataset}.campaign_settings`
+    WHERE PARSE_DATE('%Y-%m-%d', date) >= DATE_SUB(CURRENT_DATE(),  INTERVAL 30 DAY)
+    GROUP BY campaign_id
+      ) AS CS ON AGA.campaign_id = CS.campaign_id
+  WHERE AGA.asset_performance NOT IN ('PENDING','UNKNOWN')
+    AND AGA.campaign_id
+      IN (SELECT campaign_id FROM `{bq_dataset}.campaign_settings`)
+  GROUP BY ALL
+);

--- a/bq_queries/09-bpscore.sql
+++ b/bq_queries/09-bpscore.sql
@@ -13,19 +13,20 @@
 # limitations under the License.
 
 CREATE OR REPLACE TABLE `{bq_dataset}_bq.campaignbpscore_${format(today(),'yyyyMMdd')}` AS
-( 
+(
   SELECT
     date,
     CD.account_id,
     CD.account_name,
     CD.campaign_id,
     CD.campaign_name,
+    CD.campaign_status,
     round(
       (
         IF(CD.url_expansion_opt_out=true,1,0) +
         CD.audience_signals_score +
-        IF(CD.missing_sitelinks=0,1,missing_sitelinks/4) + 
-        CASE 
+        IF(CD.missing_sitelinks=0,1,missing_sitelinks/4) +
+        CASE
           WHEN positive_geo_target_type_configured_good='X' AND negative_geo_target_type_configured_good='X' THEN 0
           WHEN positive_geo_target_type_configured_good='Yes' AND negative_geo_target_type_configured_good='X' THEN 0.5
           WHEN positive_geo_target_type_configured_good='X' AND negative_geo_target_type_configured_good='Yes' THEN 0.5
@@ -33,6 +34,6 @@ CREATE OR REPLACE TABLE `{bq_dataset}_bq.campaignbpscore_${format(today(),'yyyyM
         END
       )/4,2
     ) AS campaign_bp_score
-  FROM `{bq_dataset}_bq.campaign_data`AS CD 
-  GROUP BY 1,2,3,4,5,6
+  FROM `{bq_dataset}_bq.campaign_data`AS CD
+  GROUP BY ALL
 )

--- a/bq_queries/10-assetgroupbestpractices.sql
+++ b/bq_queries/10-assetgroupbestpractices.sql
@@ -40,8 +40,8 @@ WITH
       count_long_headlines,
       count_short_descriptions,
       count_short_headlines,
-      (IF(count_descriptions >= 4, 1, 0) + 
-       IF(count_headlines >= 11, 1, 0) + 
+      (IF(count_descriptions >= 4, 1, 0) +
+       IF(count_headlines >= 11, 1, 0) +
        IF(count_long_headlines >= 2, 1, 0)) / 3 AS text_score
     FROM `{bq_dataset}_bq.text_assets`
   ),
@@ -59,10 +59,10 @@ WITH
       count_landscape_logos,
       count_square,
       count_square_logos,
-      (IF(count_landscape >= 4, 1, 0) + 
-       IF(count_square >= 4, 1, 0) + 
-       IF(count_portrait >= 4, 1, 0) + 
-       IF(count_landscape_logos >= 1, 1, 0) + 
+      (IF(count_landscape >= 4, 1, 0) +
+       IF(count_square >= 4, 1, 0) +
+       IF(count_portrait >= 4, 1, 0) +
+       IF(count_landscape_logos >= 1, 1, 0) +
        IF(count_square_logos >= 1, 1, 0)) / 5 AS image_score
     FROM `{bq_dataset}_bq.image_assets`
   ),
@@ -82,6 +82,7 @@ SELECT
   AGS.account_name,
   AGS.campaign_id,
   AGS.campaign_name,
+  AGS.campaign_status,
   AGS.asset_group_id,
   AGS.asset_group_name,
   AGS.ad_strength,
@@ -89,11 +90,11 @@ SELECT
   V.video_score,
   T.text_score,
   I.image_score,
-  "Recommended" AS recommendation_type,
+  'Recommended' AS recommendation_type,
   IF(T.count_descriptions < 4, 4 - T.count_descriptions, 0) AS missing_descriptions,
   IF(T.count_headlines < 11, 11 - T.count_headlines, 0) AS missing_headlines,
   IF(T.count_long_headlines < 2, 2 - T.count_long_headlines, 0) AS missing_long_headlines,
-  IF((I.count_landscape + I.count_square + I.count_portrait + I.count_logos) < 12, 
+  IF((I.count_landscape + I.count_square + I.count_portrait + I.count_logos) < 12,
   12 - (I.count_landscape + I.count_square + I.count_portrait + I.count_logos), 0) AS missing_images,
   IF(I.count_landscape < 4, 4 - I.count_landscape, 0) AS missing_landscape,
   IF(I.count_square < 4, 4 - I.count_square, 0) AS missing_square,
@@ -102,7 +103,7 @@ SELECT
   IF(I.count_square_logos = 0, 1, 0) AS missing_square_logos,
   IF(I.count_landscape_logos = 0, 1, 0) AS missing_landscape_logos,
   IF(V.count_videos < 3, 3 - V.count_videos, 0) AS missing_video,
-  IF(ASA.number_of_audience_signals IS NOT NULL,"Yes","X") AS audience_signals,
+  IF(ASA.number_of_audience_signals IS NOT NULL, 'Yes', 'X') AS audience_signals,
   OCID.ocid
 FROM `{bq_dataset}.assetgroupsummary` AS AGS
   INNER JOIN VIDEO_DATA AS V
@@ -130,6 +131,7 @@ SELECT
   AGS.account_name,
   AGS.campaign_id,
   AGS.campaign_name,
+  AGS.campaign_status,
   AGS.asset_group_id,
   AGS.asset_group_name,
   AGS.ad_strength,
@@ -137,11 +139,11 @@ SELECT
   V.video_score,
   T.text_score,
   I.image_score,
-  "Maximum" AS recommendation_type,
+  'Maximum' AS recommendation_type,
   IF(T.count_descriptions < 5, 5 - T.count_descriptions, 0) AS missing_descriptions,
   IF(T.count_headlines < 15, 15 - T.count_headlines, 0) AS missing_headlines,
   IF(T.count_long_headlines < 5, 5 - T.count_long_headlines, 0) AS missing_long_headlines,
-  IF((I.count_landscape + I.count_square + I.count_portrait + I.count_logos) < 20, 
+  IF((I.count_landscape + I.count_square + I.count_portrait + I.count_logos) < 20,
   20 - (I.count_landscape + I.count_square + I.count_portrait + I.count_logos), 0) AS missing_images,
   IF(I.count_landscape < 4, 4 - I.count_landscape, 0) AS missing_landscape,
   IF(I.count_square < 4, 4 - I.count_square, 0) AS missing_square,

--- a/bq_queries/11-assetgroupbestpracticessnapshots.sql
+++ b/bq_queries/11-assetgroupbestpracticessnapshots.sql
@@ -39,8 +39,8 @@ text_data AS (
     count_long_headlines,
     count_short_descriptions,
     count_short_headlines,
-    (IF(count_descriptions >= 4, 1, 0) + 
-     IF(count_headlines >= 11, 1, 0) + 
+    (IF(count_descriptions >= 4, 1, 0) +
+     IF(count_headlines >= 11, 1, 0) +
      IF(count_long_headlines >= 2, 1, 0)) / 3 AS text_score
   FROM `{bq_dataset}_bq.text_assets`
 ),
@@ -58,20 +58,20 @@ image_data AS (
     count_landscape_logos,
     count_square,
     count_square_logos,
-    (IF(count_landscape >= 4, 1, 0) + 
-     IF(count_square >= 4, 1, 0) + 
-     IF(count_portrait >= 4, 1, 0) + 
-     IF(count_landscape_logos >= 1, 1, 0) + 
+    (IF(count_landscape >= 4, 1, 0) +
+     IF(count_square >= 4, 1, 0) +
+     IF(count_portrait >= 4, 1, 0) +
+     IF(count_landscape_logos >= 1, 1, 0) +
      IF(count_square_logos >= 1, 1, 0)) / 5 AS image_score
   FROM `{bq_dataset}_bq.image_assets`
 ),
 audience_signals_count AS (
-    SELECT 
+    SELECT
       AGS.campaign_id AS campaign_id,
       AGS.asset_group_id,
-      COUNT(DISTINCT AGS.asset_group_id) AS number_of_audience_signals, 
+      COUNT(DISTINCT AGS.asset_group_id) AS number_of_audience_signals,
     FROM `{bq_dataset}.assetgroupsignal` AGS
-    GROUP BY 
+    GROUP BY
       campaign_id,
       asset_group_id
   )
@@ -80,7 +80,8 @@ SELECT
     AGS.account_id,
     AGS.account_name,
     AGS.campaign_id,
-    AGS.campaign_name,  
+    AGS.campaign_name,
+    AGS.campaign_status,
     AGS.asset_group_id,
     AGS.asset_group_name,
     AGS.ad_strength,
@@ -104,7 +105,7 @@ SELECT
     IF(I.count_landscape_logos = 0, 1, 0) AS missing_landscape_logos,
     IF(V.count_videos < 3, 3 - V.count_videos, 0) AS missing_video,
     IF(V.count_videos < 5, 5 - V.count_videos, 0) AS missing_video_max,
-    IF(ASA.number_of_audience_signals IS NOT NULL,"Yes","X") AS audience_signals
+    IF(ASA.number_of_audience_signals IS NOT NULL, 'Yes', 'X') AS audience_signals
 FROM `{bq_dataset}.assetgroupsummary` AGS
 INNER JOIN video_data AS V
  ON AGS.account_id = V.account_id

--- a/bq_queries/12-campaign_settings.sql
+++ b/bq_queries/12-campaign_settings.sql
@@ -42,7 +42,7 @@ WITH
       ROUND(AVG(text_score), 2) AS text_score,
       ROUND(AVG(image_score), 2) AS image_score
     FROM `{bq_dataset}_bq.assetgroupbpscore_*`
-    GROUP BY 1,2,3
+    GROUP BY 1, 2, 3
   ),
   CAMPAIGN_BEST_PRACTICES AS (
     SELECT
@@ -51,7 +51,7 @@ WITH
       campaign_id,
       campaign_bp_score
     FROM `{bq_dataset}_bq.campaignbpscore_*`
-    GROUP BY 1,2,3,4
+    GROUP BY 1, 2, 3, 4
   )
 SELECT
     C.date,
@@ -59,6 +59,7 @@ SELECT
     C.account_name,
     C.campaign_id,
     C.campaign_name,
+    C.campaign_status,
     C.bidding_strategy,
     C.budget_amount,
     C.total_budget,

--- a/bq_queries/13-campaign_scores_union.sql
+++ b/bq_queries/13-campaign_scores_union.sql
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 CREATE OR REPLACE TABLE `{bq_dataset}_bq.campaign_scores_union` AS
-WITH 
+WITH
 score_types AS
 (
   SELECT 'Video Score' AS score_type UNION ALL
@@ -22,11 +22,12 @@ score_types AS
   SELECT 'Campaign Best Practice Score'
 ),
 
-scores_union AS 
+scores_union AS
 (
-  SELECT 
+  SELECT
     `date`,
     campaign_name,
+    campaign_status,
     video_score,
     image_score,
     text_score,
@@ -36,15 +37,16 @@ scores_union AS
   CROSS JOIN score_types S
 )
 
-SELECT 
+SELECT
   `date`,
   campaign_name,
+  campaign_status,
   score_type,
   CASE score_type
-    WHEN "Video Score" THEN video_score
-    WHEN "Image Score" THEN image_score
-    WHEN "Text Score" THEN text_score
-    WHEN "Campaign Best Practice Score" THEN campaign_bp_score
+    WHEN 'Video Score' THEN video_score
+    WHEN 'Image Score' THEN image_score
+    WHEN 'Text Score' THEN text_score
+    WHEN 'Campaign Best Practice Score' THEN campaign_bp_score
     ELSE NULL
   END AS score
 FROM scores_union

--- a/bq_queries/14-poor_assets_summary.sql
+++ b/bq_queries/14-poor_assets_summary.sql
@@ -14,7 +14,21 @@
 
 CREATE OR REPLACE TABLE `{bq_dataset}_bq.poor_assets_summary` AS
     SELECT
+        ABP.campaign_status,
         COUNT(distinct ABP.campaign_id) AS num_campaigns,
         COUNT(distinct ABP.asset_group_id) AS num_asset_groups
     FROM `{bq_dataset}_bq.assetgroupbestpractices` ABP
     WHERE ad_strength = 'POOR'
+    GROUP BY ALL
+  -- Adding dummy rows to avoid errors when filtering on campaign status
+  UNION ALL
+    SELECT
+      'ENABLED' AS campaign_status,
+      0 AS num_campaigns,
+      0 AS num_asset_groups
+  UNION ALL
+    SELECT
+      'PAUSED' AS campaign_status,
+      0 AS num_campaigns,
+      0 AS num_asset_groups
+

--- a/bq_queries/19-assetgroupperformance.sql
+++ b/bq_queries/19-assetgroupperformance.sql
@@ -29,6 +29,7 @@ CREATE OR REPLACE TABLE `{bq_dataset}_bq.assetgroup_performance` AS (
       AGS.account_name,
       AGS.campaign_id,
       AGS.campaign_name,
+      AGS.campaign_status,
       AGS.asset_group_id,
       AGS.asset_group_name,
       AGS.asset_group_status,

--- a/google_ads_queries/ad_group_asset.sql
+++ b/google_ads_queries/ad_group_asset.sql
@@ -16,6 +16,12 @@ SELECT
   asset.id AS asset_id,
   ad_group_asset.ad_group~0 AS ad_group_id,
   customer.id AS account_id,
-  ad_group_asset.field_type AS asset_type
+  ad_group_asset.field_type AS asset_type,
+  segments.date AS date,
+  metrics.impressions AS impressions,
+  metrics.clicks AS clicks,
+  metrics.conversions AS conversions,
+  metrics.conversions_value AS conversions_value,
+  metrics.cost_micros AS cost_micros
 FROM
   ad_group_asset

--- a/google_ads_queries/ad_group_asset.sql
+++ b/google_ads_queries/ad_group_asset.sql
@@ -16,6 +16,8 @@ SELECT
   asset.id AS asset_id,
   ad_group_asset.ad_group~0 AS ad_group_id,
   customer.id AS account_id,
+  campaign.advertising_channel_type,
+  campaign.status AS campaign_status,
   ad_group_asset.field_type AS asset_type,
   segments.date AS date,
   metrics.impressions AS impressions,
@@ -25,3 +27,7 @@ SELECT
   metrics.cost_micros AS cost_micros
 FROM
   ad_group_asset
+WHERE campaign.advertising_channel_type = 'PERFORMANCE_MAX'
+  AND campaign.status IN ('ENABLED', 'PAUSED')
+  AND segments.date >= '{start_date}'
+  AND segments.date <= '{end_date}'

--- a/google_ads_queries/assetgroupasset.sql
+++ b/google_ads_queries/assetgroupasset.sql
@@ -18,12 +18,14 @@ SELECT
   asset_group.status AS asset_group_status,
   campaign.id AS campaign_id,
   campaign.name AS campaign_name,
+  campaign.status AS campaign_status,
   asset.id AS asset_id,
+  asset_group_asset.status AS asset_status,
   customer.id AS account_id,
   customer.descriptive_name AS account_name,
   asset.type AS asset_type,
   asset_group_asset.field_type AS asset_sub_type,
-  asset_group_asset.performance_label as asset_performance,
+  asset_group_asset.performance_label AS asset_performance,
   asset.image_asset.file_size AS image_file_size,
   asset.image_asset.full_size.url AS image_url,
   asset.text_asset.text AS text_asset_text,
@@ -33,7 +35,6 @@ SELECT
   asset.youtube_video_asset.youtube_video_title AS video_title
 FROM asset_group_asset
 WHERE campaign.advertising_channel_type = 'PERFORMANCE_MAX'
-AND campaign.status = 'ENABLED'
-AND asset_group.status = 'ENABLED'
-AND asset_group_asset.status = 'ENABLED'
+AND asset_group.status IN ('ENABLED', 'PAUSED')
+AND asset_group_asset.status IN ('ENABLED', 'PAUSED')
 AND asset_group_asset.source = 'ADVERTISER'

--- a/google_ads_queries/assetgroupasset.sql
+++ b/google_ads_queries/assetgroupasset.sql
@@ -32,9 +32,18 @@ SELECT
   asset.image_asset.full_size.height_pixels AS image_height,
   asset.image_asset.full_size.width_pixels AS image_width,
   asset.youtube_video_asset.youtube_video_id AS video_id,
-  asset.youtube_video_asset.youtube_video_title AS video_title
+  asset.youtube_video_asset.youtube_video_title AS video_title,
+  segments.date AS date,
+  metrics.impressions AS impressions,
+  metrics.clicks AS clicks,
+  metrics.conversions AS conversions,
+  metrics.conversions_value AS conversions_value,
+  metrics.cost_micros AS cost_micros
 FROM asset_group_asset
 WHERE campaign.advertising_channel_type = 'PERFORMANCE_MAX'
-AND asset_group.status IN ('ENABLED', 'PAUSED')
-AND asset_group_asset.status IN ('ENABLED', 'PAUSED')
-AND asset_group_asset.source = 'ADVERTISER'
+  AND campaign.status IN ('ENABLED', 'PAUSED')
+  AND asset_group.status IN ('ENABLED', 'PAUSED')
+  AND asset_group_asset.status IN ('ENABLED', 'PAUSED')
+  AND asset_group_asset.source = 'ADVERTISER'
+  AND segments.date >= '{start_date}'
+  AND segments.date <= '{end_date}'

--- a/google_ads_queries/assetgroupsignal.sql
+++ b/google_ads_queries/assetgroupsignal.sql
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SELECT 
+SELECT
     asset_group_signal.audience.audience AS audience_signals,
     campaign.id AS campaign_id,
     asset_group.id AS asset_group_id
-FROM 
-    asset_group_signal 
-WHERE 
+FROM
+    asset_group_signal
+WHERE
     asset_group_signal.audience.audience IS NOT NULL

--- a/google_ads_queries/assetgroupsummary.sql
+++ b/google_ads_queries/assetgroupsummary.sql
@@ -19,13 +19,14 @@ SELECT
   asset_group.status AS asset_group_status,
   campaign.id AS campaign_id,
   campaign.name AS campaign_name,
+  campaign.status AS campaign_status,
   customer.id AS account_id,
   customer.descriptive_name AS account_name,
   asset_group.ad_strength AS ad_strength,
   metrics.clicks AS clicks,
   metrics.conversions AS conversions,
   metrics.all_conversions AS all_conversions,
-  metrics.cost_micros As cost,
+  metrics.cost_micros AS cost,
   metrics.conversions_value AS conversions_value,
   metrics.impressions AS impressions,
   metrics.ctr AS ctr,
@@ -36,7 +37,7 @@ FROM
   asset_group
 WHERE
   campaign.advertising_channel_type = 'PERFORMANCE_MAX'
-  AND asset_group.status = 'ENABLED'
-  AND campaign.status = 'ENABLED'
+  AND asset_group.status IN ('ENABLED', 'PAUSED')
+  AND campaign.status IN ('ENABLED', 'PAUSED')
   AND segments.date >= '{start_date}'
   AND segments.date <= '{end_date}'

--- a/google_ads_queries/campaign_lifecycle_goals.sql
+++ b/google_ads_queries/campaign_lifecycle_goals.sql
@@ -13,11 +13,8 @@
 # limitations under the License.
 
 SELECT
-    campaign.id AS campaign_id,
-    campaign.status AS campaign_status,
-    conversion_goal_campaign_config.custom_conversion_goal~0 AS custom_conversion_goal_id,
-    customer.id AS account_id,
-    campaign.advertising_channel_type AS campaign_type
-FROM conversion_goal_campaign_config
-WHERE campaign.advertising_channel_type IN ('PERFORMANCE_MAX', 'SEARCH')
-AND conversion_goal_campaign_config.custom_conversion_goal IS NOT NULL
+  campaign_lifecycle_goal.campaign,
+  campaign_lifecycle_goal.customer_acquisition_goal_settings.optimization_mode,
+  campaign_lifecycle_goal.customer_acquisition_goal_settings.value_settings.value,
+  campaign_lifecycle_goal.customer_acquisition_goal_settings.value_settings.high_lifetime_value
+FROM campaign_lifecycle_goal

--- a/google_ads_queries/campaign_settings.sql
+++ b/google_ads_queries/campaign_settings.sql
@@ -18,6 +18,8 @@ SELECT
     customer.descriptive_name AS account_name,
     campaign.id AS campaign_id,
     campaign.name AS campaign_name,
+    campaign.resource_name AS campaign_resource_name,
+    campaign.start_date AS campaign_start_date,
     campaign.status AS campaign_status,
     campaign.url_expansion_opt_out AS url_expansion_opt_out,
     campaign.bidding_strategy_type AS bidding_strategy,
@@ -35,16 +37,17 @@ SELECT
     campaign.maximize_conversion_value.target_roas AS campaign_mcv_troas,
     campaign.target_roas.target_roas AS campaign_troas,
     campaign.selective_optimization.conversion_actions AS selective_optimization_conversion_actions,
-    campaign.shopping_setting.merchant_id as gmc_id,
-    campaign.optimization_score as optiscore,
-    campaign.geo_target_type_setting.negative_geo_target_type as negative_geo_target_type,
-    campaign.geo_target_type_setting.positive_geo_target_type as positive_geo_target_type,
+    campaign.shopping_setting.merchant_id AS gmc_id,
+    campaign.optimization_score AS optiscore,
+    campaign.geo_target_type_setting.negative_geo_target_type AS negative_geo_target_type,
+    campaign.geo_target_type_setting.positive_geo_target_type AS positive_geo_target_type,
+    campaign.asset_automation_settings AS asset_automation_settings,
     metrics.cost_micros AS cost,
     metrics.conversions AS conversions,
     metrics.conversions_value AS conversions_value,
     metrics.all_conversions_value AS all_conversions_value
 FROM campaign
-WHERE campaign.advertising_channel_type = "PERFORMANCE_MAX"
+WHERE campaign.advertising_channel_type = 'PERFORMANCE_MAX'
     AND segments.date >= "{start_date}"
     AND segments.date <= "{end_date}"
-    AND campaign.status = 'ENABLED'
+    AND campaign.status IN ('ENABLED', 'PAUSED')

--- a/google_ads_queries/campaignasset.sql
+++ b/google_ads_queries/campaignasset.sql
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 SELECT
-  customer.descriptive_name as account_name,
-  campaign.id as campaign_id,
-  customer.id as account_id,
-  campaign.name as campaign_name,
-  campaign.advertising_channel_type as campaign_type,
-  campaign.status as campaign_status,
-  campaign_asset.field_type as asset_type
-FROM campaign_asset 
+  customer.descriptive_name AS account_name,
+  campaign.id AS campaign_id,
+  customer.id AS account_id,
+  campaign.name AS campaign_name,
+  campaign.advertising_channel_type AS campaign_type,
+  campaign.status AS campaign_status,
+  campaign_asset.field_type AS asset_type
+FROM campaign_asset
 WHERE campaign.advertising_channel_type = 'PERFORMANCE_MAX'
-AND campaign.status = 'ENABLED'
+AND campaign.status IN ('ENABLED', 'PAUSED')

--- a/google_ads_queries/campaignconversionaction.sql
+++ b/google_ads_queries/campaignconversionaction.sql
@@ -13,30 +13,30 @@
 # limitations under the License.
 
 
-SELECT 
-    campaign.id as campaign_id, 
-    campaign.name as campaign_name, 
-    campaign.status as campaign_status, 
-    campaign.advertising_channel_type as campaign_type,
-    customer.id as account_id,
-    customer.descriptive_name as account_name,
-    segments.conversion_action_category as conversion_action_category,
-    segments.conversion_action as conversion_action_id,
-    segments.conversion_action_name as conversion_action_name, 
-    segments.date as date,
-    metrics.all_conversions as all_conversions, 
-    metrics.all_conversions_by_conversion_date as all_conversions_by_conversion_date,
-    metrics.all_conversions_value as all_conversions_value,
-    metrics.all_conversions_value_by_conversion_date as all_conversions_value_by_conversion_date, 
-    metrics.conversions as conversions,
-    metrics.conversions_by_conversion_date as conversions_by_conversion_date, 
-    metrics.conversions_value as conversions_value, 
-    metrics.conversions_value_by_conversion_date as conversions_value_by_conversion_date,
-    metrics.value_per_conversion as value_per_conversion, 
-    metrics.value_per_all_conversions as value_per_all_conversions,
-    metrics.view_through_conversions as view_through_conversions
-FROM campaign 
-WHERE campaign.advertising_channel_type = "PERFORMANCE_MAX"
+SELECT
+    campaign.id AS campaign_id,
+    campaign.name AS campaign_name,
+    campaign.status AS campaign_status,
+    campaign.advertising_channel_type AS campaign_type,
+    customer.id AS account_id,
+    customer.descriptive_name AS account_name,
+    segments.conversion_action_category AS conversion_action_category,
+    segments.conversion_action AS conversion_action_id,
+    segments.conversion_action_name AS conversion_action_name,
+    segments.date AS date,
+    metrics.all_conversions AS all_conversions,
+    metrics.all_conversions_by_conversion_date AS all_conversions_by_conversion_date,
+    metrics.all_conversions_value AS all_conversions_value,
+    metrics.all_conversions_value_by_conversion_date AS all_conversions_value_by_conversion_date,
+    metrics.conversions AS conversions,
+    metrics.conversions_by_conversion_date AS conversions_by_conversion_date,
+    metrics.conversions_value AS conversions_value,
+    metrics.conversions_value_by_conversion_date AS conversions_value_by_conversion_date,
+    metrics.value_per_conversion AS value_per_conversion,
+    metrics.value_per_all_conversions AS value_per_all_conversions,
+    metrics.view_through_conversions AS view_through_conversions
+FROM campaign
+WHERE campaign.advertising_channel_type = 'PERFORMANCE_MAX'
 AND segments.date >= "{start_date}"
 AND segments.date <= "{end_date}"
-AND campaign.status = 'ENABLED'
+AND campaign.status IN ('ENABLED', 'PAUSED')

--- a/google_ads_queries/conversion_category.sql
+++ b/google_ads_queries/conversion_category.sql
@@ -14,9 +14,10 @@
 
 SELECT
     campaign.id AS campaign_id,
+    campaign.status AS campaign_status,
     customer.id AS account_id,
     campaign_conversion_goal.category AS conversion_name,
     campaign.advertising_channel_type AS campaign_type
 FROM campaign_conversion_goal
-WHERE campaign.advertising_channel_type IN ("PERFORMANCE_MAX", "SEARCH")
-AND campaign_conversion_goal.biddable = true
+WHERE campaign.advertising_channel_type IN ('PERFORMANCE_MAX', 'SEARCH')
+AND campaign_conversion_goal.biddable = TRUE

--- a/google_ads_queries/conversion_split.sql
+++ b/google_ads_queries/conversion_split.sql
@@ -18,7 +18,7 @@ SELECT
     segments.conversion_action~0 AS conversion_action_id,
     segments.conversion_action_name AS conversion_name,
     metrics.conversions AS conversions,
-    customer.id as account_id,
+    customer.id AS account_id,
     campaign.advertising_channel_type AS campaign_type
 FROM ad_group_ad
 WHERE

--- a/google_ads_queries/customer.sql
+++ b/google_ads_queries/customer.sql
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 SELECT
-	customer.id as account_id,
-	customer.descriptive_name as account_name,
-	customer.currency_code as currency
+	customer.id AS account_id,
+	customer.descriptive_name AS account_name,
+	customer.currency_code AS currency
 FROM customer

--- a/google_ads_queries/negative_criteria.sql
+++ b/google_ads_queries/negative_criteria.sql
@@ -14,10 +14,10 @@
 
 SELECT
     campaign.id AS campaign_id,
-    campaign.status AS campaign_status,
-    conversion_goal_campaign_config.custom_conversion_goal~0 AS custom_conversion_goal_id,
-    customer.id AS account_id,
-    campaign.advertising_channel_type AS campaign_type
-FROM conversion_goal_campaign_config
-WHERE campaign.advertising_channel_type IN ('PERFORMANCE_MAX', 'SEARCH')
-AND conversion_goal_campaign_config.custom_conversion_goal IS NOT NULL
+    campaign.resource_name AS campaign_resource_name,
+    campaign_criterion.negative,
+    campaign_criterion.type,
+FROM campaign_criterion
+WHERE campaign.advertising_channel_type = 'PERFORMANCE_MAX'
+    AND campaign.status IN ('ENABLED', 'PAUSED')
+    AND campaign_criterion.negative = TRUE

--- a/google_ads_queries/pmax_placement_view.sql
+++ b/google_ads_queries/pmax_placement_view.sql
@@ -29,4 +29,4 @@ FROM performance_max_placement_view
 WHERE campaign.advertising_channel_type = "PERFORMANCE_MAX"
     AND segments.date >= "{start_date}"
     AND segments.date <= "{end_date}"
-    AND campaign.status = 'ENABLED'
+    AND campaign.status IN ('ENABLED', 'PAUSED')

--- a/google_ads_queries/recommendations.sql
+++ b/google_ads_queries/recommendations.sql
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SELECT 
-	customer.id as account_id,
-	campaign.id as campaign_id,
-	recommendation.type as rec_type
+SELECT
+	customer.id AS account_id,
+	campaign.id AS campaign_id,
+	recommendation.type AS rec_type
 FROM
 	recommendation
 WHERE
 	campaign.advertising_channel_type = 'PERFORMANCE_MAX'
-	AND recommendation.type in ('CAMPAIGN_BUDGET', 'FORECASTING_CAMPAIGN_BUDGET')
+	AND recommendation.type IN ('CAMPAIGN_BUDGET', 'FORECASTING_CAMPAIGN_BUDGET')


### PR DESCRIPTION
/!\ Breaking change: reports now return paused campaigns as well as active ones. Need to update Looker Studio template to add a filter on campaign status.

Added a campaign_status dimension to all relevant tables to allow filtering on campaign status

Added a few more checks for best practices in campaign_data table:
  - has_automatic_text_asset_automation
  - has_keyword_exclusions
  - has_users_exclusions
  - customer_acquisition_optimization_mode

Also, some minor changes to improve SQL style consistency.